### PR TITLE
[PNUDEV-27] Fix bug related to editing of big posts from admin panel

### DIFF
--- a/src/main/resources/templates/admin/post/form.ftl
+++ b/src/main/resources/templates/admin/post/form.ftl
@@ -90,7 +90,7 @@
                         ],
                     });
                     <#if post??>
-                    $('#postContentEditor').summernote('code', '${post.content}');
+                    $('#postContentEditor').summernote('code', '${post.content?js_string}');
                     </#if>
                 </script>
             </div>


### PR DESCRIPTION
The problem was next: if content contains single quote [ ' ], js cannot compile code of inserting content into summernoteEditor properly.